### PR TITLE
feat(permissions): add role-based access control for admin, manager, …

### DIFF
--- a/backend/apps/core/messages.py
+++ b/backend/apps/core/messages.py
@@ -1,0 +1,24 @@
+from django.utils.translation import gettext_lazy as _
+
+# =========================================================
+# GENERIC MESSAGES
+# =========================================================
+PERMISSION_DENIED = _("Você não tem permissão para realizar esta ação.")
+NOT_FOUND = _("Registro não encontrado.")
+INVALID_INPUT = _("Dados inválidos.")
+UNAUTHORIZED = _("Credenciais inválidas.")
+
+# =========================================================
+# AUTH MESSAGES
+# =========================================================
+USER_INACTIVE = _("Usuário inativo.")
+USER_NOT_FOUND = _("Usuário não encontrado.")
+PASSWORD_MISMATCH = _("Senha incorreta.")
+
+# =========================================================
+# VALIDATION MESSAGES
+# =========================================================
+REQUIRED_FIELD = _("Este campo é obrigatório.")
+INVALID_CPF = _("CPF inválido.")
+INVALID_CNPJ = _("CNPJ inválido.")
+INVALID_DATE = _("Data inválida.")

--- a/backend/apps/core/permissions.py
+++ b/backend/apps/core/permissions.py
@@ -1,19 +1,55 @@
-"""Permissões genéricas do app core (reutilizáveis no projeto)."""
-
 from rest_framework import permissions
+from apps.accounts.models import User
+from . import messages
+
+
+class IsAdmin(permissions.BasePermission):
+    """Permite acesso apenas a administradores."""
+
+    message = messages.PERMISSION_DENIED
+
+    def has_permission(self, request, view):
+        return (
+            request.user
+            and request.user.is_authenticated
+            and request.user.role == User.Role.ADMIN
+        )
+
+
+class IsManager(permissions.BasePermission):
+    """Permite acesso a gestores e administradores."""
+
+    message = messages.PERMISSION_DENIED
+
+    def has_permission(self, request, view):
+        if not (request.user and request.user.is_authenticated):
+            return False
+        
+        return request.user.role in [User.Role.MANAGER, User.Role.ADMIN]
+
+
+class IsAuditor(permissions.BasePermission):
+    """Permite acesso a conferentes, gestores e administradores."""
+
+    message = messages.PERMISSION_DENIED
+
+    def has_permission(self, request, view):
+        if not (request.user and request.user.is_authenticated):
+            return False
+            
+        return request.user.role in [User.Role.AUDITOR, User.Role.MANAGER, User.Role.ADMIN]
 
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
-    """Apenas o dono pode editar; outros só leitura. Objeto deve ter owner ou user."""
+    """
+    Permite escrita apenas ao dono do objeto (obj.user).
+    Leitura (SAFE_METHODS) permitida para todos autenticados.
+    """
+
+    message = messages.PERMISSION_DENIED
 
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        if hasattr(obj, "owner"):
-            return obj.owner == request.user
-
-        if hasattr(obj, "user"):
-            return obj.user == request.user
-
-        return False
+        return obj.user == request.user


### PR DESCRIPTION
…and auditor

- Implemented IsAdmin, IsManager, and IsAuditor permissions to restrict access based on user roles.
- Updated IsOwnerOrReadOnly to ensure only the object owner can edit, while authenticated users can read.