### PR TITLE
feat(cavaletes): enforce minimum slot requirement during cavalete cre…

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,11 +3,12 @@
 Este arquivo registra mudanças notáveis no backend do MetaScan.
 
 
-## [1.7.0] - 2026-02-12
+## [1.7.0] - 2026-02-14
 
 ### Adicionado
 - **Criação Dinâmica de Slots:** Funcionalidade que permite criar slots automaticamente ao cadastrar um Cavalete.
 - **API:** Campo `structure` (write-only) no endpoint de criação de cavalete (`POST /api/inventory/cavaletes/`).
+- **Validação:** Rejeição de criação com estrutura zerada (`slots_a=0` e `slots_b=0`) se o campo `structure` for enviado.
 - **Service:** Função `create_cavalete_structure` para geração em massa de slots.
 - **Testes:** Validação da criação de cavalete com estrutura de slots.
 

--- a/backend/apps/cavaletes/serializers.py
+++ b/backend/apps/cavaletes/serializers.py
@@ -82,5 +82,8 @@ class CavaleteSerializer(serializers.ModelSerializer):
         
         if slots_a < 0 or slots_b < 0:
             raise serializers.ValidationError("Quantidade de slots não pode ser negativa.")
+        
+        if slots_a == 0 and slots_b == 0:
+            raise serializers.ValidationError("O cavalete deve ter pelo menos 1 slot (Lado A ou B).")
             
         return value

--- a/backend/apps/cavaletes/tests/test_views.py
+++ b/backend/apps/cavaletes/tests/test_views.py
@@ -66,6 +66,20 @@ class TestCavaleteViewSet:
         assert slots.filter(side="A").count() == 2
         assert slots.filter(side="B").count() == 1
 
+    def test_create_cavalete_with_empty_structure_fails(self, api_client, manager_user):
+        """Não deve permitir criar cavalete com estrutura zerada se structure for enviado."""
+        api_client.force_authenticate(user=manager_user)
+        url = reverse("cavaletes:cavalete-list")
+        data = {
+            "code": "C004",
+            "type": "DEFAULT",
+            "structure": {"slots_a": 0, "slots_b": 0},
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "O cavalete deve ter pelo menos 1 slot" in str(response.data["structure"])
+
     def test_create_cavalete_auditor_forbidden(self, api_client, auditor_user):
         """Conferente NÃO pode criar cavalete."""
         api_client.force_authenticate(user=auditor_user)

--- a/docs/product/backlog-backend.md
+++ b/docs/product/backlog-backend.md
@@ -83,7 +83,7 @@ Implementar o domínio de cavaletes e slots: modelos, CRUD, exportação Excel, 
 ### Entregas principais
 
 - Seguir [ARCHITECTURE](../backend/ARCHITECTURE.md) (UniqueConstraint, related_name, Admin, validação no serializer).
-- App `cavaletes`: modelos Cavalete (name, code, type, user FK, status) e Slot (cavalete FK, side, number, product_code, product_description, quantity, status); UniqueConstraint (cavalete, side, number); code/name no save(); slots conforme quantidade informada na requisição; registrar no Admin.
+- App `cavaletes`: modelos Cavalete (code, type, user FK, status) e Slot (cavalete FK, side, number, product_code, product_description, quantity, status); UniqueConstraint (cavalete, side, number); slots conforme quantidade informada na requisição; registrar no Admin.
 - CavaleteViewSet: CRUD, filtros, search, ordering; get_queryset por role (conferente só vê atribuídos); actions export (Excel), assign_user, assign (bulk).
 - SlotViewSet: CRUD, filtros; regra “editar produto/quantidade só se status=auditing” no serializer; actions start_confirmation e finish_confirmation; opcional start_all/finish_all.
 - Rotas em config/urls.py (cavaletes, slots).

--- a/docs/system/api-spec.md
+++ b/docs/system/api-spec.md
@@ -26,7 +26,8 @@ Este documento descreve os endpoints da API do MetaScan (conferência de estoque
   - Gestor: Vê todos.
   - Conferente: Vê apenas os atribuídos a ele.
 - `POST /api/inventory/cavaletes/` - Criar cavalete (Gestor)
-  - Payload Opcional: `structure: { "slots_a": int, "slots_b": int }` para criação automática de slots.
+  - Payload: `code`, `type` (DEFAULT, PINE).
+  - Payload Opcional: `structure: { "slots_a": int, "slots_b": int }`. Se enviado, deve ter pelo menos 1 slot no total.
 - `GET /api/inventory/cavaletes/{id}/` - Detalhes do cavalete
 - `PATCH /api/inventory/cavaletes/{id}/` - Atualizar cavalete (Gestor)
 - `DELETE /api/inventory/cavaletes/{id}/` - Excluir cavalete (Gestor)

--- a/docs/system/business-rules.md
+++ b/docs/system/business-rules.md
@@ -18,7 +18,7 @@ Este documento descreve regras de negócio do MetaScan (conferência de estoque 
 ### Regras do MetaScan
 
 - **Cavaletes:** Código único. Tipo (Default/Pine). Status: `AVAILABLE`, `IN_PROGRESS`, `COMPLETED`, `BLOCKED`.
-  - **Criação:** Ao criar um cavalete, é possível definir uma estrutura inicial (quantidade de slots Lado A e Lado B) para geração automática dos slots.
+  - **Criação:** Ao criar um cavalete com estrutura inicial, é obrigatório definir pelo menos um slot (Lado A ou B).
 - **Slots:**
   - Posição definida por Lado (A/B) e Número.
   - Workflow de 3 estados: `AVAILABLE` → `AUDITING` → `COMPLETED`.


### PR DESCRIPTION
…ation

- Updated the CavaleteSerializer to reject creation requests with zero slots for both sides when the `structure` field is provided.
- Enhanced tests to validate the new validation rule for cavalete creation.
- Updated API documentation to reflect the requirement for at least one slot when using the `structure` field.