### PR TITLE
feat(accounts): add user listing endpoint and update documentation

### DIFF
--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -25,8 +25,8 @@ Este documento descreve a arquitetura e os componentes do backend do **MetaScan*
 **apps.accounts**
 - Modelo customizado `User` com `role` (Admin, Manager, Auditor)
 - Serializers genéricos (`UserSerializer`, `UserProfileSerializer`)
-- Views para perfil e detalhes de usuário
-- Endpoints: `/api/users/profile/` e `/api/users/<id>/`
+- Views: `UserListView` (listagem, Gestor/Admin), perfil e detalhes de usuário
+- Endpoints: `GET /api/users/` (lista paginada), `/api/users/profile/`, `/api/users/<id>/`
 - Configuração do Django Admin para User
 
 **apps.inventory**

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Este arquivo registra mudanças notáveis no backend do MetaScan.
 
+## [1.8.1] - 2026-02-14
+
+### Adicionado
+- **Accounts:** Endpoint `GET /api/users/` — listagem de usuários ativos (Gestor/Admin), resposta paginada; usado para dropdown de atribuição de conferente no frontend.
+
 ## [1.8.0] - 2026-02-14
 
 ### Adicionado

--- a/backend/README.md
+++ b/backend/README.md
@@ -185,6 +185,12 @@ O arquivo `settings.py` carrega o `.env` por padrão, mas o Docker Compose Local
 - `POST /api/token/refresh/` - Renovar access token
 - `POST /api/token/verify/` - Verificar token
 
+### Usuários
+- `GET /api/users/` - Listar usuários ativos (Gestor/Admin; resposta paginada)
+- `GET /api/users/profile/` - Perfil do usuário logado
+- `PATCH /api/users/profile/` - Atualizar perfil
+- `GET /api/users/<id>/` - Detalhes de usuário por ID
+
 ### Sankhya
 - `GET /api/sankhya/products/<code>/` - Consulta de produto por código (autenticada)
 

--- a/backend/apps/accounts/README.md
+++ b/backend/apps/accounts/README.md
@@ -20,4 +20,6 @@ Estende `AbstractUser` do Django.
 
 - `POST /api/token/`: Obter token JWT (Login).
 - `POST /api/token/refresh/`: Atualizar token.
+- `GET /api/users/`: Listar usuários ativos (Gestor/Admin). Resposta paginada. Usado para dropdown de atribuição de cavalete.
 - `GET /api/users/profile/`: Dados do usuário logado.
+- `GET /api/users/<id>/`: Detalhes de um usuário por ID.

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -1,11 +1,12 @@
 """URLs do app accounts (perfil e detalhe de usuário)."""
 
 from django.urls import path
-from .views import UserProfileView, UserDetailView
+from .views import UserListView, UserProfileView, UserDetailView
 
 app_name = "accounts"
 
 urlpatterns = [
+    path("", UserListView.as_view(), name="list"),
     path("profile/", UserProfileView.as_view(), name="profile"),
     path("<int:pk>/", UserDetailView.as_view(), name="detail"),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -5,9 +5,18 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 
+from apps.core.permissions import IsManager
 from .serializers import UserSerializer, UserProfileSerializer
 
 User = get_user_model()
+
+
+class UserListView(generics.ListAPIView):
+    """Lista usuários (Gestor/Admin). Usado para dropdown de atribuição de cavalete."""
+
+    permission_classes = [IsAuthenticated, IsManager]
+    serializer_class = UserSerializer
+    queryset = User.objects.filter(is_active=True).order_by("username")
 
 
 class UserProfileView(generics.RetrieveUpdateAPIView):

--- a/docs/system/api-spec.md
+++ b/docs/system/api-spec.md
@@ -18,8 +18,11 @@ Este documento descreve os endpoints da API do MetaScan (conferência de estoque
 
 ## Usuários
 
+- `GET /api/users/` - Listar usuários ativos (Gestor/Admin). Usado para dropdown de atribuição de cavalete. Resposta paginada.
 - `GET /api/users/profile/` - Perfil do usuário logado
 - `PATCH /api/users/profile/` - Atualização do perfil logado
+- `GET /api/users/{id}/` - Detalhes de um usuário por ID
+
 ## Cavaletes (Inventory)
 
 - `GET /api/inventory/cavaletes/` - Listar cavaletes


### PR DESCRIPTION
- Introduced `GET /api/users/` endpoint for listing active users (Gestor/Admin) with paginated responses.
- Updated views, serializers, and URLs to support the new user listing functionality.
- Enhanced documentation in README and API spec to reflect the new endpoint and its usage.